### PR TITLE
Anniversary Update: 1.15.8

### DIFF
--- a/Hemlock.lua
+++ b/Hemlock.lua
@@ -755,15 +755,11 @@ function Hemlock:ConfirmationPopup(popupText,frame,pName)
 	end	
 	-- Popup dialog
 	StaticPopupDialogs["HEMLOCK_CONFIRMATION"] = {
-		text = "|cff55ff55Hemlock|r\n" .. popupText,
+		text = "|cff55ff55Hemlock|r\n" .. popupText .. "\n\n" .. GetCoinTextureString(totalReagentPrice),
 		button1 = self:L("popup_buy"),
 		button2 = self:L("popup_cancel"),
-		hasMoneyFrame = 1,
 		OnAccept = function()
 			Hemlock:ConfirmationPopupAccepted(frame,pName)
-		end,
-		OnShow = function(self)
-			MoneyFrame_Update(self.moneyFrame, totalReagentPrice);
 		end,
 		timeout = 0,
 		whileDead = true,

--- a/Hemlock.toc
+++ b/Hemlock.toc
@@ -1,4 +1,4 @@
-## Interface: 20000
+## Interface: 11508
 ## Version: 2.5
 ## Title: |cff00ff00Hemlock Reloaded|r
 ## Notes: automate poison buying and creation


### PR DESCRIPTION
Fix: Reagent Costs Display now uses GetCoinTextureString directly in Popuptext. (was using MoneyFrame_Update which errors in new Anniversary Update)